### PR TITLE
Allow mathbb symbols

### DIFF
--- a/template.tex
+++ b/template.tex
@@ -10,6 +10,7 @@
 \usepackage{changepage}
 \usepackage{framed}
 \usepackage{hyperref}
+\usepackage{amssymb}
 \bibliographystyle{abbrvnat}
 
 % Make list items more compact

--- a/template.yml
+++ b/template.yml
@@ -48,3 +48,4 @@ packages:
   - natbib
   - xcolor
   - changepage
+  - amssymb


### PR DESCRIPTION
In rendering our book I discovered `\mathbb{}` did not work. This PR fixes the template.

If there is a better way, please comment and I'll close.